### PR TITLE
Improve perf with Array.init

### DIFF
--- a/BinaryTrees/Program.fs
+++ b/BinaryTrees/Program.fs
@@ -36,12 +36,13 @@ let main args =
     let longLivedTree = bottomUpTree maxDepth
 
     let results =
-        [| for depth in MIN_DEPTH..2..maxDepth do
-             yield async {
+        Array.init ((maxDepth - MIN_DEPTH)/2) (fun depth ->
+             async {
+                let depth = depth * 2 + MIN_DEPTH
                 let iterations = 1 <<< (maxDepth - depth + MIN_DEPTH)
                 let check = Array.init iterations (fun _ -> bottomUpTree(depth).itemCheck()) |> Array.sum
                 return sprintf "%d\t trees of depth %d\t check: %d" iterations depth check
-             } |]
+             })
         |> Async.Parallel
         |> Async.RunSynchronously
 


### PR DESCRIPTION
On my machine the original code best run was
![image](https://user-images.githubusercontent.com/1097246/32650650-448bea20-c607-11e7-9a35-04c86471662d.png)
Array init best result is
![image](https://user-images.githubusercontent.com/1097246/32650712-79d9834a-c607-11e7-9723-986777df7997.png)
also the with ilspy it's look more performant